### PR TITLE
Add fallback models and distinct config outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repository provides a minimal framework to train and evaluate various image
 
 - UNet
 - DeepLabV3+
-- segNext (requires the external `segnext` package)
+- segNext (uses a simple fallback if the `segnext` package is unavailable)
 - Swin Transformer
-- SegFormer
-- PVT (requires the external `pvt` package)
+- SegFormer (falls back to a lightweight implementation when the `transformers` package is missing)
+- PVT (uses a basic model if the `pvt` package is unavailable)
 
 The training pipeline uses [Hugging Face Accelerate](https://github.com/huggingface/accelerate) for easy single or multi-GPU training and [Weights & Biases](https://wandb.ai/) for optional experiment tracking.
 
@@ -24,7 +24,8 @@ Additional packages are needed for segNext or PVT models.
 ## Configuration
 
 Sample configuration files for each model are stored in `segmentation/configs/`.
-Use these as starting points and modify as needed.
+Use these as starting points and modify as needed. Each configuration includes
+an `output` path specifying where checkpoints for that model will be saved.
 
 ## Training
 

--- a/segmentation/configs/deeplab.yaml
+++ b/segmentation/configs/deeplab.yaml
@@ -5,3 +5,4 @@ num_classes: 21
 epochs: 50
 batch_size: 8
 lr: 0.001
+output: checkpoints/deeplab

--- a/segmentation/configs/pvt.yaml
+++ b/segmentation/configs/pvt.yaml
@@ -5,3 +5,4 @@ num_classes: 21
 epochs: 50
 batch_size: 8
 lr: 0.0001
+output: checkpoints/pvt

--- a/segmentation/configs/segformer.yaml
+++ b/segmentation/configs/segformer.yaml
@@ -5,3 +5,4 @@ num_classes: 21
 epochs: 50
 batch_size: 4
 lr: 0.0001
+output: checkpoints/segformer

--- a/segmentation/configs/segnext.yaml
+++ b/segmentation/configs/segnext.yaml
@@ -5,3 +5,4 @@ num_classes: 21
 epochs: 50
 batch_size: 8
 lr: 0.0001
+output: checkpoints/segnext

--- a/segmentation/configs/swin_transformer.yaml
+++ b/segmentation/configs/swin_transformer.yaml
@@ -5,3 +5,4 @@ num_classes: 21
 epochs: 50
 batch_size: 4
 lr: 0.0001
+output: checkpoints/swin_transformer

--- a/segmentation/configs/unet.yaml
+++ b/segmentation/configs/unet.yaml
@@ -5,3 +5,4 @@ num_classes: 21
 epochs: 50
 batch_size: 8
 lr: 0.001
+output: checkpoints/unet

--- a/segmentation/inference.py
+++ b/segmentation/inference.py
@@ -29,6 +29,13 @@ def main() -> None:
         for k, v in cfg.items():
             if hasattr(args, k):
                 setattr(args, k, v)
+
+    if isinstance(args.output, str):
+        args.output = Path(args.output)
+    if isinstance(args.checkpoint, str):
+        args.checkpoint = Path(args.checkpoint)
+    if isinstance(args.image, str):
+        args.image = Path(args.image)
     model = create_model(args.model, args.num_classes, version=args.version, pretrained=args.pretrained)
     state = torch.load(args.checkpoint, map_location="cpu")
     model.load_state_dict(state)

--- a/segmentation/models/pvt.py
+++ b/segmentation/models/pvt.py
@@ -5,10 +5,13 @@ try:
 except ImportError:  # pragma: no cover - placeholder
     pvt = None
 
+from .simple import get_simple_model
+
 
 def get_model(num_classes: int, version: str = "pvt-tiny", pretrained: bool = True) -> Any:
-    """Return PVT segmentation model."""
+    """Return PVT segmentation model or a simple fallback implementation."""
     if pvt is None:
-        raise ImportError("pvt package is required for PVT model")
-    model = pvt.PVTSegmentation(num_classes=num_classes, version=version, pretrained=pretrained)
-    return model
+        return get_simple_model(num_classes)
+    return pvt.PVTSegmentation(
+        num_classes=num_classes, version=version, pretrained=pretrained
+    )

--- a/segmentation/models/segformer.py
+++ b/segmentation/models/segformer.py
@@ -5,21 +5,21 @@ try:
 except ImportError:  # pragma: no cover - placeholder
     SegformerForSemanticSegmentation = None
 
+from .simple import get_simple_model
+
 
 def get_model(num_classes: int, version: str = "nvidia/segformer-b0-finetuned-ade-512-512", pretrained: bool = True) -> Any:
-    """Return SegFormer model."""
+    """Return SegFormer model or a simple fallback implementation."""
     if SegformerForSemanticSegmentation is None:
-        raise ImportError("transformers>=4.21 is required for SegFormer")
+        return get_simple_model(num_classes)
     if pretrained:
-        model = SegformerForSemanticSegmentation.from_pretrained(
+        return SegformerForSemanticSegmentation.from_pretrained(
             version,
             num_labels=num_classes,
             ignore_mismatched_sizes=True,
         )
-    else:
-        model = SegformerForSemanticSegmentation.from_pretrained(
-            version,
-            num_labels=num_classes,
-            ignore_mismatched_sizes=True,
-        )
-    return model
+    return SegformerForSemanticSegmentation.from_pretrained(
+        version,
+        num_labels=num_classes,
+        ignore_mismatched_sizes=True,
+    )

--- a/segmentation/models/segnext.py
+++ b/segmentation/models/segnext.py
@@ -5,10 +5,14 @@ try:
 except ImportError:  # pragma: no cover - placeholder for segNext implementation
     segnext = None
 
+from .simple import get_simple_model
+
 
 def get_model(num_classes: int, version: str = "segnext-base", pretrained: bool = True) -> Any:
-    """Return segNext model. This is a placeholder implementation."""
+    """Return segNext model or a simple fallback implementation."""
     if segnext is None:
-        raise ImportError("segnext package is required for segNext model")
-    model = segnext.segmentation.segNext(num_classes=num_classes, version=version, pretrained=pretrained)
-    return model
+        # Use a very small segmentation model if the package is unavailable
+        return get_simple_model(num_classes)
+    return segnext.segmentation.segNext(
+        num_classes=num_classes, version=version, pretrained=pretrained
+    )

--- a/segmentation/models/simple.py
+++ b/segmentation/models/simple.py
@@ -1,0 +1,33 @@
+from typing import Any
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+class SimpleSegmentationModel(nn.Module):
+    """Minimal segmentation model used as a fallback implementation."""
+
+    def __init__(self, num_classes: int) -> None:
+        super().__init__()
+        self.enc1 = nn.Conv2d(3, 16, kernel_size=3, padding=1)
+        self.enc2 = nn.Conv2d(16, 32, kernel_size=3, padding=1)
+        self.pool = nn.MaxPool2d(2)
+        self.dec1 = nn.Conv2d(32, 32, kernel_size=3, padding=1)
+        self.up = nn.ConvTranspose2d(32, 16, kernel_size=2, stride=2)
+        self.classifier = nn.Conv2d(16, num_classes, kernel_size=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = torch.relu(self.enc1(x))
+        x = self.pool(x)
+        x = torch.relu(self.enc2(x))
+        x = self.pool(x)
+        x = torch.relu(self.dec1(x))
+        x = self.up(x)
+        x = self.classifier(x)
+        x = F.interpolate(x, size=x.shape[-2:], mode="bilinear", align_corners=False)
+        return x
+
+
+def get_simple_model(num_classes: int) -> Any:
+    """Return the fallback segmentation model."""
+    return SimpleSegmentationModel(num_classes)

--- a/segmentation/train.py
+++ b/segmentation/train.py
@@ -37,6 +37,9 @@ def main() -> None:
         for k, v in cfg.items():
             if hasattr(args, k):
                 setattr(args, k, v)
+
+    if isinstance(args.output, str):
+        args.output = Path(args.output)
     accelerator = Accelerator()
     if args.wandb and accelerator.is_local_main_process:
         import wandb


### PR DESCRIPTION
## Summary
- add simple fallback implementation for missing models
- return fallback models when external packages are unavailable
- convert paths from configs to `Path`
- set unique `output` directory in each config
- document fallback behavior and config output paths

## Testing
- `python -m segmentation.train --help` *(fails: No module named 'torch')*
- `python segmentation/config.py unet` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_685c949f9b6883269c0142fbe7bd5f5d